### PR TITLE
Add configurable templates for notification messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,8 @@ Possible 'event -> hook' states are:
     "scm": "git",
     "log_level": "debug",
     "local_user": "johndoe",
-    "server": {
-      "name": "my_server.com",
-      "user": "my_ssh_user"
-    }
+    "remote_host": "my_server.com",
+    "remote_user": "my_ssh_user"
   }
 }
 ```

--- a/lib/capistrano/rocket_chat/version.rb
+++ b/lib/capistrano/rocket_chat/version.rb
@@ -1,7 +1,7 @@
 module Capistrano
   module Rocket
     module Chat
-      VERSION = "0.1.9"
+      VERSION = "0.1.10"
     end
   end
 end

--- a/lib/capistrano/tasks/rocket_chat.cap
+++ b/lib/capistrano/tasks/rocket_chat.cap
@@ -36,20 +36,25 @@ def get_config_vars()
     scm: fetch(:scm),
     log_level: fetch(:log_level),
     local_user: @task.local_user,
-    server: {
-      name: @host.hostname,
-      user: @host.user
-    }
-   }
+    remote_host: @host.hostname,
+    remote_user:  @host.user
+  }.merge(fetch(:rocket_chat_settings, {}))
 end
+
+DEFAULT_NOTIFICATION_TEMPLATE = "%{event_hook} deployment to '%{remote_host}' on branch '%{branch}' to stage '%{stage}'"
 
 def notify(event_hook)
 
-  config = get_config_vars
+  config = get_config_vars.merge(event_hook: event_hook)
 
   raise "\n\nERROR::ROCKET-CHAT-TASK: config option 'rocket_chat_webhook_url' is not set\n\n" unless config[:rocket_chat_url]
   
-  notification_text = "#{event_hook} deployment to '#{config[:server][:name]}' on branch '#{config[:branch]}' to stage '#{config[:stage]}'"
+  notification_template = case event_hook
+                          when :starting then config[:start_deployment_template]
+                          when :finished then config[:finish_deployment_template]
+                          end || DEFAULT_NOTIFICATION_TEMPLATE
+
+  notification_text = notification_template % config
 
   if dry_run?
     puts "[Rocket Chat] #{event_hook}"


### PR DESCRIPTION
* changes the notification message from a simple string to a template string
* Adds a default template that contains the same info as the simple string before
* adds the option to overwrite the template string for `:starting` or `:finished` events
* changes the data structure returned by `get_config_vars` to a plain hash so it can be used for interpolation in the template strings
* Bump gem version from 0.1.9 to 0.1.10